### PR TITLE
QQ parse bugfix, and continued refactoring of constants

### DIFF
--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -436,7 +436,7 @@ class PLSSDesc:
         But you CANNOT assign, pop, or insert with a `PLSSDesc`
         directly. If any of that functionality is required, work
         directly with the `.parsed_tracts` attribute. Or, get a new
-        `plss.TractList` to work with, thus:
+        `pytrs.TractList` to work with, thus:
         `new_tractlist = some_plssdesc.parse(commit=False)`
         (`TractList` is a subclass of the built-in `list`.)
         """

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -1299,7 +1299,8 @@ class PLSSDesc:
         Simple printing of the arg-specified attributes for each Tract
         in the .parsed_tracts list.
         """
-        print(self.tracts_to_str(attributes))
+        # This functionality is handled by TractList method.
+        self.parsed_tracts.print_data(attributes)
         return
 
 
@@ -2317,6 +2318,14 @@ class TractList(list):
         """
 
         print(self.quick_desc(delim=delim, newline=newline))
+
+    def print_data(self, *attributes) -> None:
+        """
+        Simple printing of the arg-specified attributes for each Tract
+        in this TractList.
+        """
+        print(self.tracts_to_str(attributes))
+        return
 
     def list_trs(self, remove_duplicates=False):
         """

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -4556,11 +4556,13 @@ def _pass_back_halves(aliquot_components: list) -> list:
     """
     INTERNAL USE:
     Quarters that precede halves in an aliquot block are nonstandard
-    but technically accurative. This function adjusts them to be the
-    standard version.
+    but technically accurate. This function adjusts them to the
+    equivalent description where the half occurs before the quarter.
+
     For example, ``'NE/4N/2'`` (passed here as ``['N', 'NE']``) is
     better described as the ``'N/2NE/4'``. Converted here to
     ``['NE', 'N']``.
+
     Similarly, the ``SE/4W/2'`` (passed here as ``['W', 'SE']``) is
     better described as the ``'E/2SW/4'``. Converted here to
     ``['SW', 'E']``.

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -308,7 +308,7 @@ class PLSSDesc:
 
         # Whether we should require a colon between Section ## and tract
         # description (for TRS_DESC and S_DESC_TR layouts):
-        self.require_colon = True
+        self.require_colon = "default_colon"
 
         # Whether to include any divisions of lots
         # (i.e. 'N/2 of Lot 1' -> 'N2 of L1')
@@ -495,7 +495,7 @@ class PLSSDesc:
 
     def parse(
             self, text=None, layout=None, clean_up=None, init_parse_qq=None,
-            clean_qq=None, require_colon='default_colon', segment=None,
+            clean_qq=None, require_colon=None, segment=None,
             commit=True, qq_depth_min=None, qq_depth_max=None, qq_depth=None,
             break_halves=None):
         """
@@ -524,10 +524,12 @@ class PLSSDesc:
         :param require_colon: Whether to require a colon between the
         section number and the following description (only has an effect
         on 'TRS_desc' or 'S_desc_TR' layouts).
-        If not specified, it will default to a 'two-pass' method, where
-        first it will require the colon; and if no matching sections are
-        found, it will do a second pass where colons are not required.
-        Setting as `True` or `False` here prevent the two-pass method.
+        If not specified, it will default to whatever was set at init;
+        and unless otherwise specified there, will default to a 'two-
+        pass' method, where first it will require the colon; and if no
+        matching sections are found, it will do a second pass where
+        colons are not required. Setting as `True` or `False` here
+        prevent the two-pass method.
             ex: 'Section 14 NE/4'
                 `require_colon=True` --> no match
                 `require_colon=False` --> match (but beware false
@@ -589,6 +591,9 @@ class PLSSDesc:
             flagText = self.orig_desc
         else:
             flagText = text
+
+        if require_colon is None:
+            require_colon = self.require_colon
 
         # When layout is specified at init, or when calling
         # `.parse(layout=<string>)`, we prevent _parse_segment() from deducing,
@@ -3159,7 +3164,7 @@ def _findall_matching_sec(text, layout=None, require_colon='default_colon'):
 
 
 def _parse_segment(
-        text_block, layout=None, clean_up=None, require_colon='default_colon',
+        text_block, layout=None, clean_up=None, require_colon=None,
         handed_down_config=None, init_parse_qq=False, clean_qq=None,
         qq_depth_min=None, qq_depth_max=None, qq_depth=None,
         break_halves=None):
@@ -3259,6 +3264,9 @@ def _parse_segment(
 
     if layout not in _IMPLEMENTED_LAYOUTS:
         layout = PLSSDesc._deduce_segment_layout(text_block)
+
+    if require_colon is None:
+        require_colon = 'default_colon'
 
     segParseBag = ParseBag(parent_type='PLSSDesc')
 

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -1806,6 +1806,12 @@ class Tract:
         (equivalent to what would be stored in `.lots_qqs`).
         """
 
+        if commit:
+            # Wipe any prior parsed results.
+            self.lots = []
+            self.qqs = []
+            self.lots_qqs = []
+
         # TODO: Generate a list (saved as an attribute) of slice_indexes
         #   of the `pp_desc` for the text that was incorporated into
         #   lots and QQ's vs. not.

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -88,39 +88,59 @@ IMPLEMENTED_LAYOUT_EXAMPLES = (
 )
 
 # For aliquot parsing.
-QQ_HALVES = ('N', 'S', 'E', 'W')
-QQ_QUARTERS = ('NE', 'NW', 'SE', 'SW')
+N = 'N'
+S = 'S'
+E = 'E'
+W = 'W'
+NE = 'NE'
+NW = 'NW'
+SE = 'SE'
+SW = 'SW'
+ALL = 'ALL'
+
+QQ_HALVES = (N, S, E, W)
+QQ_QUARTERS = (NE, NW, SE, SW)
 QQ_SUBDIVIDE_DEFINITIONS = {
-    'ALL': QQ_QUARTERS,
-    'N': ('NE', 'NW'),
-    'S': ('SE', 'SW'),
-    'E': ('NE', 'SE'),
-    'W': ('NW', 'SW'),
+    ALL: QQ_QUARTERS,
+    N: (NE, NW),
+    S: (SE, SW),
+    E: (NE, SE),
+    W: (NW, SW),
 }
-QQ_NS = ("N", "S")
-QQ_EW = ("E", "W")
+QQ_NS = (N, S)
+QQ_EW = (E, W)
 QQ_SAME_AXIS = {
-    "N": QQ_NS,
-    "S": QQ_NS,
-    "E": QQ_EW,
-    "W": QQ_EW
+    N: QQ_NS,
+    S: QQ_NS,
+    E: QQ_EW,
+    W: QQ_EW
 }
+
+# Clean aliquot abbreviations with fraction, for aliquot preprocessing.
+NE_FRAC = 'NE¼'
+NW_FRAC = 'NW¼'
+SE_FRAC = 'SE¼'
+SW_FRAC = 'SW¼'
+N2_FRAC = 'N½'
+S2_FRAC = 'S½'
+E2_FRAC = 'E½'
+W2_FRAC = 'W½'
 
 # Define what should replace matches of each regex that is used in the
 # _scrub_aliquots() function.
 QQ_SCRUBBER_DEFINITIONS = {
-    NE_regex: 'NE¼',
-    NW_regex: 'NW¼',
-    SE_regex: 'SE¼',
-    SW_regex: 'SW¼',
-    N2_regex: 'N½',
-    S2_regex: 'S½',
-    E2_regex: 'E½',
-    W2_regex: 'W½',
-    cleanNE_regex: 'NE¼',
-    cleanNW_regex: 'NW¼',
-    cleanSE_regex: 'SE¼',
-    cleanSW_regex: 'SW¼'
+    NE_regex: NE_FRAC,
+    NW_regex: NW_FRAC,
+    SE_regex: SE_FRAC,
+    SW_regex: SW_FRAC,
+    N2_regex: N2_FRAC,
+    S2_regex: S2_FRAC,
+    E2_regex: E2_FRAC,
+    W2_regex: W2_FRAC,
+    cleanNE_regex: NE_FRAC,
+    cleanNW_regex: NW_FRAC,
+    cleanSE_regex: SE_FRAC,
+    cleanSW_regex: SW_FRAC
 }
 
 CONFIG_ERROR = TypeError(

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -2437,6 +2437,11 @@ class ParseBag:
             self.lots = []
             self.lot_acres = {}
 
+        # This is only ever filled by `_findall_matching_tr()`. It will
+        # contain a list of tuples, being twprge matches and their start
+        # and end positions (indexes) in the string that was searched.
+        self.twprge_position_list = []
+
     def absorb(self, target_pb):
         """
         Absorb (i.e. append or set) the relevant attributes of a child
@@ -2861,7 +2866,7 @@ def _findall_matching_tr(text, layout=None) -> ParseBag:
     INTERNAL USE:
 
     Find T&R's that appropriately match the layout. Returns a ParseBag
-    that contains an ad-hoc `.trPosList` attribute, which holds a list
+    with a filled-in `.twprge_position_list` attribute, holding a list
     of tuples, each containing a T&R (as '000n000w' or fewer digits),
     and its start and end position in the string.
     """
@@ -2955,8 +2960,8 @@ def _findall_matching_tr(text, layout=None) -> ParseBag:
             i = i + len(tr_mo.group())
             continue
 
-    # Ad-hoc attribute (T&R/position list)
-    trParseBag.trPosList = wTRList
+    # Set attribute (T&R/position list)
+    trParseBag.twprge_position_list = wTRList
 
     return trParseBag
 
@@ -2987,9 +2992,9 @@ def _segment_by_tr(text, layout=None, twprge_first=None):
     # Search for all T&R's that match the layout requirements.
     trMatchPB = _findall_matching_tr(text, layout=layout)
 
-    # Pull ad-hoc `.trPosList` attribute from the ParseBag object. Do
-    # not absorb the rest.
-    wTRList = trMatchPB.trPosList
+    # Pull `.twprge_position_list` attribute from the ParseBag object.
+    # Do not absorb the rest.
+    wTRList = trMatchPB.twprge_position_list
 
     if wTRList == []:
         # If no T&R's had been matched, return the text block as single
@@ -3359,9 +3364,9 @@ def _parse_segment(
     # Find matching TR's that are appropriate to our layout (should only
     # be one, due to segmentation):
     trPB = _findall_matching_tr(text_block)
-    # Pull the ad-hoc `.trPosList` attribute from the ParseBag object,
+    # Pull `.twprge_position_list` attribute from the ParseBag object,
     # and absorb the rest of the data into segParseBag:
-    wTRList = trPB.trPosList
+    wTRList = trPB.twprge_position_list
     segParseBag.absorb(trPB)
 
     # Find matching Sections and MultiSections that are appropriate to

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -88,32 +88,32 @@ IMPLEMENTED_LAYOUT_EXAMPLES = (
 )
 
 # For aliquot parsing.
-N = 'N'
-S = 'S'
-E = 'E'
-W = 'W'
-NE = 'NE'
-NW = 'NW'
-SE = 'SE'
-SW = 'SW'
-ALL = 'ALL'
+_N = 'N'
+_S = 'S'
+_E = 'E'
+_W = 'W'
+_NE = 'NE'
+_NW = 'NW'
+_SE = 'SE'
+_SW = 'SW'
+_ALL = 'ALL'
 
-QQ_HALVES = (N, S, E, W)
-QQ_QUARTERS = (NE, NW, SE, SW)
+QQ_HALVES = (_N, _S, _E, _W)
+QQ_QUARTERS = (_NE, _NW, _SE, _SW)
 QQ_SUBDIVIDE_DEFINITIONS = {
-    ALL: QQ_QUARTERS,
-    N: (NE, NW),
-    S: (SE, SW),
-    E: (NE, SE),
-    W: (NW, SW),
+    _ALL: QQ_QUARTERS,
+    _N: (_NE, _NW),
+    _S: (_SE, _SW),
+    _E: (_NE, _SE),
+    _W: (_NW, _SW),
 }
-QQ_NS = (N, S)
-QQ_EW = (E, W)
+QQ_NS = (_N, _S)
+QQ_EW = (_E, _W)
 QQ_SAME_AXIS = {
-    N: QQ_NS,
-    S: QQ_NS,
-    E: QQ_EW,
-    W: QQ_EW
+    _N: QQ_NS,
+    _S: QQ_NS,
+    _E: QQ_EW,
+    _W: QQ_EW
 }
 
 # Clean aliquot abbreviations with fraction, for aliquot preprocessing.

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -2931,7 +2931,8 @@ def _findall_matching_tr(text, layout=None) -> ParseBag:
         # desc_STR layout -- ex. 'Section 1 of T154N-R97W'
         interveners = ['in', 'of', ',', 'all of', 'all in', 'within', 'all within']
         if (
-            secFound and text[j:i].strip() in interveners
+            secFound
+            and text[j:i].strip().lower() in interveners
             and layout in [TRS_DESC, S_DESC_TR]
         ):
             # In TRS_Desc and S_DESC_TR layouts specifically, this is

--- a/pytrs/parser/parser.py
+++ b/pytrs/parser/parser.py
@@ -155,6 +155,13 @@ DEFAULT_EW_ERROR = ValueError(
 )
 
 
+_ERR_SEC = 'secError'
+_ERR_TWPRGE = 'TRerr'
+
+_E_FLAG_SECERR = 'secError'
+_E_FLAG_TWPRGE_ERR = 'TRerr'
+
+
 class PLSSDesc:
     """
     Each object of this class is a full PLSS description, taking the raw
@@ -730,9 +737,9 @@ class PLSSDesc:
                     ('trError', TractObj.trs + ':' + TractObj.desc))
                 bigPB.desc_is_flawed = True
             if TractObj.trs[-2:] == 'or':
-                bigPB.e_flags.append('secError')
+                bigPB.e_flags.append(_E_FLAG_SECERR)
                 bigPB.e_flag_lines.append(
-                    ('secError', TractObj.trs + ':' + TractObj.desc))
+                    (_E_FLAG_SECERR, TractObj.trs + ':' + TractObj.desc))
                 bigPB.desc_is_flawed = True
 
         # Check for warning flags (and a couple error flags).
@@ -1352,7 +1359,7 @@ class Tract:
             Ex: Sec 1, T154N-R97W -> '154n97w01'
                 Sec 14, T1S-R9E -> '1s9e14'
     NOTE: If there was a flawed parse where Twp/Rge and/or Sec could not
-        be successfully identified, .trs may contain 'TRerr_' and/or
+        be successfully identified, .trs may contain 'TRerr' and/or
         'secError'.
     .twp -- The Twp portion of .trs, a string (ex: '154n')
     .rge -- The Rge portion of .trs, a string (ex: '97w')
@@ -1463,7 +1470,7 @@ class Tract:
         # format), _unpack it into the component parts
         self.twp, self.rge, self.sec = break_trs(trs)
         if self.sec is None:
-            self.sec = 'secError'
+            self.sec = _ERR_SEC
         self.twprge = self.twp + self.rge
 
         # Whether fatal flaws were identified during the parsing of the
@@ -3452,7 +3459,7 @@ def _parse_segment(
         # initial TR is the only difference.
 
         # Defaults to a T&R error.
-        working_tr = 'TRerr_'
+        working_tr = _ERR_TWPRGE
 
         # For TR_DESC_S, will pop the working_tr when we encounter the
         # first TR. However, for desc_STR, need to pre-set our working_tr
@@ -3462,11 +3469,11 @@ def _parse_segment(
 
         # Description block comes before section in this layout, so we
         # pre-set the working_sec and working_multiSec (if any are available):
-        working_sec = 'secError'
+        working_sec = _ERR_SEC
         if len(working_sec_list) > 0:
             working_sec = working_sec_list.pop(0)
 
-        working_multiSec = ['secError']
+        working_multiSec = [_ERR_SEC]
         if len(working_multiSec_list) > 0:
             working_multiSec = working_multiSec_list.pop(0)
 
@@ -3519,7 +3526,7 @@ def _parse_segment(
             if markerType == 'tr_start':  # Pull the next T&R in our list
                 if len(working_tr_list) == 0:
                     # Will cause a TR error if another TRS+Desc is created:
-                    working_tr = 'TRerr_'
+                    working_tr = _ERR_TWPRGE
                 else:
                     working_tr = working_tr_list.pop(0)
                 continue
@@ -3571,20 +3578,20 @@ def _parse_segment(
                 TractObj = new_tract(
                     clean_as_needed(
                         text_block[secErrorWriteBackToPos:mrkrsLst[i + 1]].strip()),
-                    'secError')
+                        _ERR_SEC)
                 segParseBag.parsed_tracts.append(TractObj)
 
             elif markerType == 'sec_start':
                 if len(working_sec_list) == 0:
                     # Will cause a section error if another TRS+Desc is created
-                    working_sec = 'secError'
+                    working_sec = _ERR_SEC
                 else:
                     working_sec = working_sec_list.pop(0)
 
             elif markerType == 'multiSec_start':
                 if len(working_multiSec_list) == 0:
                     # Will cause a section error if another TRS+Desc is created
-                    working_multiSec = ['secError']
+                    working_multiSec = [_ERR_SEC]
                 else:
                     working_multiSec = working_multiSec_list.pop(0)
 
@@ -3629,14 +3636,14 @@ def _parse_segment(
 
         # Defaults to a T&R error if no T&R's were identified, but
         # pre-set our T&R (if one is available):
-        working_tr = 'TRerr_'
+        working_tr = _ERR_TWPRGE
         if len(working_tr_list) > 0:
             working_tr = working_tr_list.pop(0)
 
-        # Default to a 'secError' for this layout. Will change when we
+        # Default to a _ERR_SEC for this layout. Will change when we
         # meet the first sec and multiSec respectively.
-        working_sec = 'secError'
-        working_multiSec = ['secError']
+        working_sec = _ERR_SEC
+        working_multiSec = [_ERR_SEC]
 
         finalRun = False
 
@@ -3678,7 +3685,7 @@ def _parse_segment(
             if markerType == 'sec_start':
                 if len(working_sec_list) == 0:
                     # Will cause a section error if another TRS+Desc is created
-                    working_sec = 'secError'
+                    working_sec = _ERR_SEC
                 else:
                     working_sec = working_sec_list.pop(0)
                 #continue
@@ -3686,7 +3693,7 @@ def _parse_segment(
             elif markerType == 'multiSec_start':
                 if len(working_multiSec_list) == 0:
                     # Will cause a section error if another TRS+Desc is created
-                    working_multiSec = ['secError']
+                    working_multiSec = [_ERR_SEC]
                 else:
                     working_multiSec = working_multiSec_list.pop(0)
 
@@ -3721,7 +3728,7 @@ def _parse_segment(
             elif markerType == 'tr_start':  # Pull the next T&R in our list
                 if len(working_tr_list) == 0:
                     # Will cause a TR error if another TRS+Desc is created:
-                    working_tr = 'TRerr_'
+                    working_tr = _ERR_TWPRGE
                 else:
                     working_tr = working_tr_list.pop(0)
 
@@ -3743,17 +3750,17 @@ def _parse_segment(
 
         if len(wTRList) == 0:
             # Defaults to a T&R error if no T&R's were identified
-            working_tr = 'TRerr_'
+            working_tr = _ERR_TWPRGE
         else:
             working_tr = wTRList[0][0]
 
         if len(wSecList) == 0:
-            working_sec = 'secError'
+            working_sec = _ERR_SEC
         else:
             working_sec = wSecList[0][0]
 
         # If no solo section was found, check for a multiSec we can pull from
-        if len(wMultiSecList) != 0 and working_sec == 'secError':
+        if len(wMultiSecList) != 0 and working_sec == _ERR_SEC:
             # Just pull the first section in the first multiSec.
             working_sec = wMultiSecList[0][0][0]
 
@@ -3765,9 +3772,9 @@ def _parse_segment(
     if layout == TRS_DESC:
 
         # Defaults to a T&R error and Sec errors for this layout.
-        working_tr = 'TRerr_'
-        working_sec = 'secError'
-        working_multiSec = ['secError']
+        working_tr = _ERR_TWPRGE
+        working_sec = _ERR_SEC
+        working_multiSec = [_ERR_SEC]
 
         finalRun = False
 
@@ -3827,7 +3834,7 @@ def _parse_segment(
                 if len(working_sec_list) == 0:
                     # If another TRS+Desc pair is created after this point,
                     # it will result in a Section error:
-                    working_sec = 'secError'
+                    working_sec = _ERR_SEC
                 else:
                     working_sec = working_sec_list.pop(0)
 
@@ -3835,7 +3842,7 @@ def _parse_segment(
                 if len(working_multiSec_list) == 0:
                     # If another GROUP of TRS+Desc pairs is created
                     # after this point, it will result in a Section error.
-                    working_multiSec = ['secError']
+                    working_multiSec = [_ERR_SEC]
                 else:
                     working_multiSec = working_multiSec_list.pop(0)
 
@@ -4811,10 +4818,10 @@ def break_trs(trs: str) -> tuple:
         ex:  '154n97w14' -> ('154n', '97w', '14')
         ex:  '154n97w' -> ('154n', '97w', None)
         ex:  '154n97wsecError' -> ('154n', '97w', 'secError')
-        ex:  'TRerr_14' -> ('TRerr', 'TRerr', '14')
+        ex:  'TRerr14' -> ('TRerr', 'TRerr', '14')
         ex:  'asdf' -> ('TRerr', 'TRerr', 'secError')"""
 
-    DEFAULT_ERRORS = ('TRerr', 'TRerr', 'secError',)
+    DEFAULT_ERRORS = (_ERR_TWPRGE, _ERR_TWPRGE, _ERR_SEC)
 
     mo = TRS_unpacker_regex.search(trs)
     if mo is None:


### PR DESCRIPTION
Bugfix: Nonstandard aliquot descriptions like `"SW/4E/2"` (where quarters occur before halves) were previously being incorrectly parsed.  This would become `['SWNE', 'SWSE']`, but it should actually be `['NWSE', 'SWSE']` (i.e. the `"W/2SE/4"`). The aliquot parser now captures this correctly.

Other changes include the continued refactoring of repeatedly used strings into constants. (This will continue in the `constants` branch.)